### PR TITLE
CASMNET-2329 - Keycloak IPv6 enablement

### DIFF
--- a/kubernetes/cray-keycloak/Chart.yaml
+++ b/kubernetes/cray-keycloak/Chart.yaml
@@ -24,7 +24,7 @@
 apiVersion: v2
 appVersion: 3.9.0
 name: cray-keycloak
-version: 5.2.1
+version: 5.3.1
 description: Deploys Keycloak for Shasta
 keywords:
 - keycloak

--- a/kubernetes/cray-keycloak/templates/ipv6-support.yaml
+++ b/kubernetes/cray-keycloak/templates/ipv6-support.yaml
@@ -1,0 +1,131 @@
+{{/*
+MIT License
+
+(C) Copyright 2023-2025 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
+
+{{- if .Values.ipv6.enabled }}
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: keycloak-ipv6
+  labels:
+    {{- include "cray-keycloak.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/resource-policy: keep
+    policies.kyverno.io/minversion: 1.6.0
+    policies.kyverno.io/subject: StatefulSet
+    policies.kyverno.io/title: Keycloak IPv6 support
+    policies.kyverno.io/description: |
+      This policy mutates the cray-keycloak StatefulSet resource and adds
+      the NetworkAttachmentDefinition annotation required for IPv6 support.
+      The policy also appends -Djava.net.preferIPv4Stack=false to the
+      JAVA_OPTS_APPEND environment variable as this is required for Keycloak
+      to be able to initiate IPv6 connections.
+spec:
+  admission: true
+  background: true
+  emitWarning: false
+  rules:
+  - match:
+      any:
+      - resources:
+          kinds:
+          - StatefulSet
+          names:
+          - cray-keycloak
+    mutate:
+      patchStrategicMerge:
+        spec:
+          template:
+            metadata:
+              annotations:
+                k8s.v1.cni.cncf.io/networks: cray-keycloak
+    name: add-network-attachment
+    skipBackgroundRequests: true
+  - match:
+      any:
+      - resources:
+          kinds:
+          - StatefulSet
+          names:
+          - cray-keycloak
+    mutate:
+      foreach:
+      - context:
+        - name: jreValue
+          variable:
+            jmesPath: element.env[?name=='JAVA_OPTS_APPEND'].value | [0]
+        list: request.object.spec.template.spec.containers
+        patchStrategicMerge:
+          spec:
+            template:
+              spec:
+                containers:
+                - env:
+                  - name: JAVA_OPTS_APPEND
+                    value: "{{`{{ jreValue }} -Djava.net.preferIPv4Stack=false`}}"
+                  name: keycloak
+        preconditions:
+          all:
+          - key: "{{`{{ element.name `}}}}" 
+            operator: Equals
+            value: keycloak
+          - key:  "{{`{{ jreValue `}}}}" 
+            operator: NotIn
+            value:
+            - '*-Djava.net.preferIPv4Stack=false*'
+    name: enable-keycloak-ipv6
+    skipBackgroundRequests: true
+  validationFailureAction: Audit
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: cray-keycloak
+  labels:
+    {{- include "cray-keycloak.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/resource-policy: keep
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.0",
+      "type": "macvlan",
+      "master": "{{ .Values.ipv6.interface }}",
+      "mode": "bridge",
+      "ipam": {
+        "type": "host-local",
+        "subnet": "{{ required "ipv6.subnet must be set if IPv6 support is enabled" .Values.ipv6.subnet }}",
+        "rangeStart": "{{ required "ipv6.rangeStart must be set if IPv6 support is enabled" .Values.ipv6.rangeStart }}",
+        "rangeEnd": "{{ required "ipv6.rangeEnd must be set if IPv6 support is enabled" .Values.ipv6.rangeEnd }}",
+        "routes": [
+          {
+            "dst": "::/0",
+            "gw": "{{ required "ipv6.gateway must be set if IPv6 support is enabled" .Values.ipv6.gateway }}"
+          }
+        ]
+      }
+    }
+{{- end }}

--- a/kubernetes/cray-keycloak/values.yaml
+++ b/kubernetes/cray-keycloak/values.yaml
@@ -346,3 +346,18 @@ keycloakx:
       mountPath: /opt/keycloak/providers
     - name: themes
       mountPath: /opt/keycloak/themes
+
+# IPv6 related settings
+# enabled - toggle feature on/off.
+# interface - Physical interface to use for the NetworkAttachmentDefinition.
+# gateway - IPv6 default route. Typically the CMN gateway address.
+# subnet - IPv6 subnet in CIDR form.
+# rangeStart/rangeEnd - Pool of IPv6 addresses to use for the cray-keycloak pods. 
+#   This pool must be large enough to accomodate the configured number of replicas.
+ipv6:
+  enabled: false
+  interface: bond0.cmn0
+  gateway: ""
+  subnet: ""
+  rangeStart: ""
+  rangeEnd: ""


### PR DESCRIPTION
## Summary and Scope

This PR adds limited IPv6 support for the `cray-keycloak` service. The scope is limited to enabling access to an upstream LDAP server via IPv6.

CSM does not (yet) deploy Kubernetes in dual-stack mode so this is achieved by creating a `macvlan` Multus NetworkAttachmentDefinition which is bound to the Customer Management Network (CMN) interface and attached to the cray-keycloak Pods to allow them direct access to an IPv6 network.

This chart relies on a third party `keycloakx` chart so making sweeping changes to the chart is undesirable. Helm also does not permit templating in values.yaml which makes selectively adding annotations to the statefulset definition tricky.  This functionality is therefore implemented by means of a Kyverno policy that is created if `ipv6.enabled` is set to true and mutates the resources into the correct state.

The Kyverno policy does the following
* Adds the `k8s.v1.cni.cncf.io/networks` annotation for the NetworkAttachmentDefinition.
* Adds the `-Djava.net.preferIPv4Stack=false` option to the `JAVA_OPTS_APPEND` environment variable which is required to allow Keycloak to initiate IPv6 connections (It logs Unsupported Address Family errors without it).

## Issues and Related PRs

* Resolves [CASMNET-2329](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2329)

## Testing

Tested on:

  * `surtur`

Test description:

Deployed the chart with the following IPv6 related settings enabled.
```
ipv6:
  enabled: true
  gateway: fdf8:413:de2c:200::1
  interface: bond0.cmn0
  rangeEnd: fdf8:413:de2c:200::110
  rangeStart: fdf8:413:de2c:200::100
  subnet: fdf8:413:de2c:200::/64
```

Verified the `NetworkAttachmentDefinition` and `ClusterPolicy` resources were created successfully.

```
ncn-m001:~ # kubectl -n services get network-attachment-definitions.k8s.cni.cncf.io cray-keycloak
NAME            AGE
cray-keycloak   3h30m

ncn-m001:~ # kubectl get cpol keycloak-ipv6
NAME            ADMISSION   BACKGROUND   READY   AGE     MESSAGE
keycloak-ipv6   true        true         True    3h30m   Ready
```

Verified that the `NetworkAttachmentDefinition` annotation was present on the StatefulSet

```
ncn-m001:~ # kubectl -n services get statefulset cray-keycloak -o yaml | yq4 .spec.template.metadata.annotations
checksum/config-startup: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
checksum/secrets: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
k8s.v1.cni.cncf.io/networks: cray-keycloak
traffic.sidecar.istio.io/excludeInboundPorts: "7600"
traffic.sidecar.istio.io/excludeOutboundPorts: "7600"
```

Verified that the `preferIPv4Stack` option was appended to `JAVA_OPTS_APPEND`

```
ncn-m001:~ # kubectl -n services get statefulset cray-keycloak -o yaml | yq4 .spec.template.spec.containers[0].env
- name: JAVA_OPTS_APPEND
  value: -Djgroups.dns.query=cray-keycloak-headless -Djava.net.preferIPv4Stack=false
```

Verified that the running Pods have IPv6 addresses assigned.

```
ncn-m001:~ # kubectl -n services get pod cray-keycloak-0 -o yaml | yq4 '.metadata.annotations | with_entries(select(.key | test("cncf")))'
k8s.v1.cni.cncf.io/network-status: |-
  [{
      "name": "kube-system/cilium",
      "interface": "eth0",
      "ips": [
          "10.32.11.122"
      ],
      "mac": "da:e1:c5:46:71:38",
      "default": true,
      "dns": {}
  },{
      "name": "services/cray-keycloak",
      "interface": "net1",
      "ips": [
          "fdf8:413:de2c:200::10d"
      ],
      "mac": "72:c7:df:9e:32:17",
      "dns": {}
  }]
k8s.v1.cni.cncf.io/networks: cray-keycloak
k8s.v1.cni.cncf.io/networks-status: |-
  [{
      "name": "kube-system/cilium",
      "interface": "eth0",
      "ips": [
          "10.32.11.122"
      ],
      "mac": "da:e1:c5:46:71:38",
      "default": true,
      "dns": {}
  },{
      "name": "services/cray-keycloak",
      "interface": "net1",
      "ips": [
          "fdf8:413:de2c:200::10d"
      ],
      "mac": "72:c7:df:9e:32:17",
      "dns": {}
  }]
```

Created a spoof DNS record to ensure surtur can only access dcldap2 via IPv6 (this step is necessary because the IPv6 LDAP server is a simple reverse proxy, the IP address can't be used as the certificate doesn't contain a SAN for that IP.

```
ncn-m001:~ # host dcldap2.hpc.amslabs.hpecorp.net
dcldap2.hpc.amslabs.hpecorp.net has IPv6 address fdf8:413:de2c:2fc:4000::2e
```

Re-installed `keycloak-users-localize` after removing the existing `shasta-user-federation-ldap` and verified that the job was able to successfully pull down users.

## Risks and Mitigations

This feature is required by a small number of customers so is disabled by default.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
